### PR TITLE
Added a way to fix ll issue on the core

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,11 +30,10 @@
     },
     "scripts": {
         "test-unit": "\"vendor/bin/phpunit\" --testsuite unit --colors=always --configuration tests/Unit/phpunit.xml.dist",
-        "test-integration": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --exclude-group AdminOnly,,,,,,,,,,,,,,,",
+        "test-integration": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --exclude-group AdminOnly",
         "test-integration-adminonly": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group AdminOnly",
         "run-tests": [
-            "@test-unit",
-            "@test-integration-"
+            "@test-unit"
         ],
         "test-integration-": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group "
     }

--- a/inc/EventManagement/ClassicSubscriberInterface.php
+++ b/inc/EventManagement/ClassicSubscriberInterface.php
@@ -1,0 +1,24 @@
+<?php
+namespace LaunchpadCore\EventManagement;
+
+interface ClassicSubscriberInterface extends SubscriberInterface {
+    /**
+     * Returns an array of events that this subscriber wants to listen to.
+     *
+     * The array key is the event name. The value can be:
+     *
+     *  * The method name
+     *  * An array with the method name and priority
+     *  * An array with the method name, priority and number of accepted arguments
+     *
+     * For instance:
+     *
+     *  * array('hook_name' => 'method_name')
+     *  * array('hook_name' => array('method_name', $priority))
+     *  * array('hook_name' => array('method_name', $priority, $accepted_args))
+     *  * array('hook_name' => array(array('method_name_1', $priority_1, $accepted_args_1)), array('method_name_2', $priority_2, $accepted_args_2)))
+     *
+     * @return array
+     */
+    public function get_subscribed_events();
+}

--- a/inc/EventManagement/EventManager.php
+++ b/inc/EventManagement/EventManager.php
@@ -28,9 +28,9 @@ class EventManager {
      * The event manager registers all the hooks that the given subscriber
      * wants to register with the WordPress Plugin API.
      *
-     * @param SubscriberInterface $subscriber Subscriber_Interface implementation.
+     * @param ClassicSubscriberInterface $subscriber Subscriber_Interface implementation.
      */
-    public function add_subscriber( SubscriberInterface $subscriber ) {
+    public function add_subscriber( ClassicSubscriberInterface $subscriber ) {
         if ( $subscriber instanceof EventManagerAwareSubscriberInterface ) {
             $subscriber->set_event_manager( $this );
         }

--- a/inc/EventManagement/OptimizedSubscriberInterface.php
+++ b/inc/EventManagement/OptimizedSubscriberInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace LaunchpadCore\EventManagement;
+
+use LaunchpadCore\EventManagement\SubscriberInterface;
+
+interface OptimizedSubscriberInterface extends SubscriberInterface
+{
+    /**
+     * Returns an array of events that this subscriber wants to listen to.
+     *
+     * The array key is the event name. The value can be:
+     *
+     *  * The method name
+     *  * An array with the method name and priority
+     *  * An array with the method name, priority and number of accepted arguments
+     *
+     * For instance:
+     *
+     *  * array('hook_name' => 'method_name')
+     *  * array('hook_name' => array('method_name', $priority))
+     *  * array('hook_name' => array('method_name', $priority, $accepted_args))
+     *  * array('hook_name' => array(array('method_name_1', $priority_1, $accepted_args_1)), array('method_name_2', $priority_2, $accepted_args_2)))
+     *
+     * @return array
+     */
+    public static function get_subscribed_events();
+}

--- a/inc/EventManagement/SubscriberInterface.php
+++ b/inc/EventManagement/SubscriberInterface.php
@@ -1,24 +1,8 @@
 <?php
+
 namespace LaunchpadCore\EventManagement;
 
-interface SubscriberInterface {
-    /**
-     * Returns an array of events that this subscriber wants to listen to.
-     *
-     * The array key is the event name. The value can be:
-     *
-     *  * The method name
-     *  * An array with the method name and priority
-     *  * An array with the method name, priority and number of accepted arguments
-     *
-     * For instance:
-     *
-     *  * array('hook_name' => 'method_name')
-     *  * array('hook_name' => array('method_name', $priority))
-     *  * array('hook_name' => array('method_name', $priority, $accepted_args))
-     *  * array('hook_name' => array(array('method_name_1', $priority_1, $accepted_args_1)), array('method_name_2', $priority_2, $accepted_args_2)))
-     *
-     * @return array
-     */
-    public function get_subscribed_events();
+interface SubscriberInterface
+{
+
 }

--- a/inc/EventManagement/Wrapper/SubscriberWrapper.php
+++ b/inc/EventManagement/Wrapper/SubscriberWrapper.php
@@ -2,33 +2,44 @@
 
 namespace LaunchpadCore\EventManagement\Wrapper;
 
+use LaunchpadCore\EventManagement\OptimizedSubscriberInterface;
 use LaunchpadCore\EventManagement\SubscriberInterface;
-use Psr\Container\ContainerInterface;
 use ReflectionClass;
+use ReflectionException;
 
 class SubscriberWrapper
 {
 
+    /**
+     * Plugin prefix.
+     * @var string
+     */
     protected $prefix = '';
 
-
     /**
-     * @var ContainerInterface
+     * Instantiate class.
+     *
+     * @param string $prefix Plugin prefix.
      */
-    protected $container;
-
-
-    /**
-     * @param string $prefix
-     */
-    public function __construct(ContainerInterface $container, string $prefix)
+    public function __construct(string $prefix)
     {
-        $this->container = $container;
         $this->prefix = $prefix;
     }
 
+    /**
+     * Wrap a subscriber will the common interface for subscribers.
+     *
+     * @param object $object Any class subscriber.
+     *
+     * @return SubscriberInterface
+     * @throws ReflectionException
+     */
     public function wrap($object): SubscriberInterface
     {
+        if($object instanceof OptimizedSubscriberInterface) {
+            return new WrappedSubscriber($object, $object->get_subscribed_events());
+        }
+
         $methods = get_class_methods($object);
         $reflectionClass = new ReflectionClass(get_class($object));
         $events = [];
@@ -56,6 +67,6 @@ class SubscriberWrapper
             }
         }
 
-        return new WrappedSubscriber($this->container, $object, $events);
+        return new WrappedSubscriber($object, $events);
     }
 }

--- a/inc/EventManagement/Wrapper/WrappedSubscriber.php
+++ b/inc/EventManagement/Wrapper/WrappedSubscriber.php
@@ -2,38 +2,32 @@
 
 namespace LaunchpadCore\EventManagement\Wrapper;
 
-use LaunchpadCore\EventManagement\SubscriberInterface;
-use Psr\Container\ContainerInterface;
+use LaunchpadCore\EventManagement\ClassicSubscriberInterface;
 
-class WrappedSubscriber implements SubscriberInterface
+class WrappedSubscriber implements ClassicSubscriberInterface
 {
     /**
-     * @var string
+     * Real Subscriber.
+     *
+     * @var object
      */
     protected $object;
 
     /**
-     * @var ContainerInterface
-     */
-    protected $container;
-
-    /**
+     * Mapping from the events from the subscriber.
+     *
      * @var array
      */
     protected $events;
 
     /**
-     * @var string
+     * Instantiate the class.
+     *
+     * @param object $object Real Subscriber.
+     * @param array $events Mapping from the events from the subscriber.
      */
-    protected $instance;
-
-    /**
-     * @param $object
-     * @param array $events
-     */
-    public function __construct( ContainerInterface $container, string $object, array $events = [] )
+    public function __construct( $object, array $events = [] )
     {
-        $this->container = $container;
         $this->object = $object;
         $this->events = $events;
     }
@@ -46,18 +40,22 @@ class WrappedSubscriber implements SubscriberInterface
         return $this->events;
     }
 
+    /**
+     * Delegate callbacks to the actual subscriber.
+     *
+     * @param string $name Name from the method.
+     * @param array $arguments Parameters from the method.
+     *
+     * @return mixed
+     */
     public function __call($name, $arguments)
     {
 
 
         if( method_exists( $this, $name ) ) {
-            return $this->{$name}(...$arguments);
+            return $this->{$name}( ...$arguments );
         }
 
-        if( ! $this->instance) {
-            $this->instance = $this->container->get($this->object);
-        }
-
-        return $this->instance->{$name}(...$arguments);
+        return $this->object->{$name}( ...$arguments );
     }
 }

--- a/tests/Integration/inc/Container/HasInflectorInterface/getInflectors.php
+++ b/tests/Integration/inc/Container/HasInflectorInterface/getInflectors.php
@@ -29,7 +29,7 @@ class Test_getInflectors extends TestCase {
 
         $container = new Container();
 
-        $plugin = new Plugin($container, $this->event_manager, new SubscriberWrapper($container, $prefix));
+        $plugin = new Plugin($container, $this->event_manager, new SubscriberWrapper($prefix));
         $plugin->load([
             'prefix' => $prefix,
             'version' => '3.16'

--- a/tests/Integration/inc/Container/PrefixAwareInterface/setPrefix.php
+++ b/tests/Integration/inc/Container/PrefixAwareInterface/setPrefix.php
@@ -29,7 +29,7 @@ class Test_setPrefix extends TestCase {
 
         $container = new Container();
 
-        $plugin = new Plugin($container, $this->event_manager, new SubscriberWrapper($container, $prefix));
+        $plugin = new Plugin($container, $this->event_manager, new SubscriberWrapper($prefix));
         $plugin->load([
             'prefix' => $prefix,
             'version' => '3.16'

--- a/tests/Integration/inc/Plugin/classes/classic/ServiceProvider.php
+++ b/tests/Integration/inc/Plugin/classes/classic/ServiceProvider.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace LaunchpadCore\Tests\Integration\inc\Plugin\classes\classic;
+
+use LaunchpadCore\Container\AbstractServiceProvider;
+
+class ServiceProvider extends AbstractServiceProvider
+{
+
+    /**
+     * @inheritDoc
+     */
+    protected function define()
+    {
+        $this->register_service(Subscriber::class);
+    }
+
+    public function get_common_subscribers(): array
+    {
+        return [
+          Subscriber::class
+        ];
+    }
+}

--- a/tests/Integration/inc/Plugin/classes/classic/Subscriber.php
+++ b/tests/Integration/inc/Plugin/classes/classic/Subscriber.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace LaunchpadCore\Tests\Integration\inc\Plugin\classes\classic;
+
+use LaunchpadCore\EventManagement\ClassicSubscriberInterface;
+
+class Subscriber implements ClassicSubscriberInterface
+{
+
+    /**
+     * @inheritDoc
+     */
+    public function get_subscribed_events()
+    {
+        return [
+            'classic_hook' => 'classic_callback'
+        ];
+    }
+
+    public function classic_callback()
+    {
+
+    }
+}

--- a/tests/Integration/inc/Plugin/classes/optimize/ServiceProvider.php
+++ b/tests/Integration/inc/Plugin/classes/optimize/ServiceProvider.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace LaunchpadCore\Tests\Integration\inc\Plugin\classes\optimize;
+
+use LaunchpadCore\Container\AbstractServiceProvider;
+
+class ServiceProvider extends AbstractServiceProvider
+{
+
+    /**
+     * @inheritDoc
+     */
+    protected function define()
+    {
+        $this->register_service(Subscriber::class);
+    }
+
+    public function get_init_subscribers(): array
+    {
+        return [
+            Subscriber::class
+        ];
+    }
+}

--- a/tests/Integration/inc/Plugin/classes/optimize/Subscriber.php
+++ b/tests/Integration/inc/Plugin/classes/optimize/Subscriber.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace LaunchpadCore\Tests\Integration\inc\Plugin\classes\optimize;
+
+use LaunchpadCore\EventManagement\OptimizedSubscriberInterface;
+
+class Subscriber implements OptimizedSubscriberInterface
+{
+
+    public static function get_subscribed_events()
+    {
+        return [
+            'optimize_init' => 'optimize_callback'
+        ];
+    }
+
+    public function optimize_callback()
+    {
+
+    }
+}

--- a/tests/Integration/inc/Plugin/classes/root/ServiceProvider.php
+++ b/tests/Integration/inc/Plugin/classes/root/ServiceProvider.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace LaunchpadCore\Tests\Integration\inc\Plugin\classes\root;
+
+use LaunchpadCore\Container\AbstractServiceProvider;
+
+class ServiceProvider extends AbstractServiceProvider
+{
+
+    /**
+     * @inheritDoc
+     */
+    protected function define()
+    {
+        $this->register_service(Subscriber::class);
+    }
+
+    public function get_init_subscribers(): array
+    {
+        return [
+          Subscriber::class
+        ];
+    }
+}

--- a/tests/Integration/inc/Plugin/classes/root/Subscriber.php
+++ b/tests/Integration/inc/Plugin/classes/root/Subscriber.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace LaunchpadCore\Tests\Integration\inc\Plugin\classes\root;
+
+use LaunchpadCore\EventManagement\SubscriberInterface;
+
+class Subscriber implements SubscriberInterface
+{
+    /**
+     * @hook root_hook
+     */
+    public function root_callback()
+    {
+
+    }
+}

--- a/tests/Integration/inc/Plugin/load.php
+++ b/tests/Integration/inc/Plugin/load.php
@@ -27,7 +27,10 @@ class Test_load extends TestCase {
         $event_setup = [
             'common_hook',
             'front_hook',
-            'init_hook'
+            'init_hook',
+            'optimize_init',
+            'classic_hook',
+            'root_hook',
         ];
 
         $event_not_setup = [
@@ -42,7 +45,7 @@ class Test_load extends TestCase {
 
         $container = new Container();
 
-        $plugin = new Plugin($container, $this->event_manager, new SubscriberWrapper($container, $prefix));
+        $plugin = new Plugin($container, $this->event_manager, new SubscriberWrapper($prefix));
         $plugin->load([
             'prefix' => $prefix,
             'version' => '3.16'
@@ -51,6 +54,9 @@ class Test_load extends TestCase {
             \LaunchpadCore\Tests\Integration\inc\Plugin\classes\admin\ServiceProvider::class,
             \LaunchpadCore\Tests\Integration\inc\Plugin\classes\front\ServiceProvider::class,
             \LaunchpadCore\Tests\Integration\inc\Plugin\classes\init\ServiceProvider::class,
+            \LaunchpadCore\Tests\Integration\inc\Plugin\classes\optimize\ServiceProvider::class,
+            \LaunchpadCore\Tests\Integration\inc\Plugin\classes\classic\ServiceProvider::class,
+            \LaunchpadCore\Tests\Integration\inc\Plugin\classes\root\ServiceProvider::class,
         ]);
 
         foreach ($event_setup as $event) {


### PR DESCRIPTION
Add a way to adapt the logic to old subscribers without adding the ll which requires the name from the subscriber class as container id.