### PR TITLE
Allow multiple spaces inside @hook doc (Closes #39)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,13 @@
-.idea
+# Vendor
 vendor
 composer.lock
+
+# Tests
+.phpunit.result.cache
+
+# Env
+.env
+.lando.yml
+
+# IDE
+.idea

--- a/inc/EventManagement/Wrapper/SubscriberWrapper.php
+++ b/inc/EventManagement/Wrapper/SubscriberWrapper.php
@@ -48,7 +48,7 @@ class SubscriberWrapper {
 			if ( ! $doc_comment ) {
 				continue;
 			}
-			$pattern = '#@hook\s(?<name>[a-zA-Z\\\-_$/]+)(\s(?<priority>[0-9]+))?#';
+			$pattern = '#@hook\s+(?<name>[a-zA-Z0-9\\\-_$/]+)(\s+(?<priority>[0-9]+))?#';
 
 			preg_match_all( $pattern, $doc_comment, $matches, PREG_PATTERN_ORDER );
 			if ( ! $matches ) {

--- a/tests/Integration/inc/Plugin/classes/common/Subscriber.php
+++ b/tests/Integration/inc/Plugin/classes/common/Subscriber.php
@@ -11,4 +11,21 @@ class Subscriber
     {
 
     }
+
+    /**
+     * @hook          common_callback_with_more_spaces
+     */
+    public function common_callback_with_more_spaces()
+    {
+
+    }
+
+    /**
+     * @hook common_callback_with_numbers_in_name_2024
+     */
+    public function common_callback_with_numbers_in_name_2024()
+    {
+
+    }
+
 }

--- a/tests/Integration/inc/Plugin/commonhookparsing.php
+++ b/tests/Integration/inc/Plugin/commonhookparsing.php
@@ -24,29 +24,12 @@ class Test_commonhookparsing extends TestCase {
             'common_callback_with_numbers_in_name_2024',
         ];
 
-        $event_not_setup = [
-            'admin_hook',
-            'init_hook',
-            'optimize_init',
-            'root_hook',
-        ];
-
-        $events =array_merge($event_setup, $event_not_setup);
-
-        foreach ($events as $event) {
-            $this->assertFalse($this->event_manager->has_callback($event), $event);
-        }
-
         $this->setup_plugin($this->prefix, [
             \LaunchpadCore\Tests\Integration\inc\Plugin\classes\common\ServiceProvider::class,
         ]);
 
         foreach ($event_setup as $event) {
             $this->assertTrue($this->event_manager->has_callback($event), $event);
-        }
-
-        foreach ($event_not_setup as $event) {
-            $this->assertFalse($this->event_manager->has_callback($event), $event);
         }
 
         $actions = [

--- a/tests/Integration/inc/Plugin/commonhookparsing.php
+++ b/tests/Integration/inc/Plugin/commonhookparsing.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace LaunchpadCore\Tests\Integration\inc\Plugin;
+
+use LaunchpadCore\EventManagement\EventManager;
+use LaunchpadCore\Tests\Integration\inc\Traits\SetupPluginTrait;
+use LaunchpadCore\Tests\Integration\TestCase;
+
+/**
+ * @covers \LaunchpadCore\Plugin::load
+ */
+class Test_commonhookparsing extends TestCase {
+    use SetupPluginTrait;
+
+    protected $prefix = 'test';
+
+    public function testShouldDoAsExpected()
+    {
+        $this->event_manager = new EventManager();
+
+        $event_setup = [
+            'common_hook',
+            'common_callback_with_more_spaces',
+            'common_callback_with_numbers_in_name_2024',
+        ];
+
+        $event_not_setup = [
+            'admin_hook',
+            'init_hook',
+            'optimize_init',
+            'root_hook',
+        ];
+
+        $events =array_merge($event_setup, $event_not_setup);
+
+        foreach ($events as $event) {
+            $this->assertFalse($this->event_manager->has_callback($event), $event);
+        }
+
+        $this->setup_plugin($this->prefix, [
+            \LaunchpadCore\Tests\Integration\inc\Plugin\classes\common\ServiceProvider::class,
+        ]);
+
+        foreach ($event_setup as $event) {
+            $this->assertTrue($this->event_manager->has_callback($event), $event);
+        }
+
+        foreach ($event_not_setup as $event) {
+            $this->assertFalse($this->event_manager->has_callback($event), $event);
+        }
+
+        $actions = [
+            "{$this->prefix}before_load",
+            "{$this->prefix}after_load",
+        ];
+
+        $filters = [
+            "{$this->prefix}container",
+            "{$this->prefix}load_provider_subscribers",
+            "{$this->prefix}load_init_subscribers",
+            "{$this->prefix}load_subscribers",
+        ];
+        foreach ($actions as $action) {
+            did_action($action);
+        }
+
+        foreach ($filters as $filter) {
+            did_filter($filter);
+        }
+    }
+
+    /**
+     * @hook $prefixload_init_subscribers
+     */
+    public function invalid_subscriber_list()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
Closes #39 

PR does: 
- Allow multiple spaces between `@hook` and hook name
- Allow multiple spaces between hook name and priority 
- Allow numbers in the hook name (we might need to add dates in the hook name)

Current regex for the `@hook` parsing: `#@hook\s(?<name>[a-zA-Z\\\-_$/]+)(\s(?<priority>[0-9]+))?#`

Proposed change to `#@hook\s+(?<name>[a-zA-Z0-9\\\-_$/]+)(\s+(?<priority>[0-9]+))?#`:
- Allow multiple spaces between `@hook` and hook name
- Allow multiple spaces between hook name and priority
- Allow numbers in the hook name (we might need to add dates in the hook name)

[Testing the new regex online](https://onlinephp.io/preg-match-all?d=q1YqSCwpSS3KU7JSUnbIyM_Pjokp1tawt8lLzE21i07UrXLUjTLQtYwBA914lRj9WG1NDaiigqLM_KLMkkq7aKASoLimvbKSjlJxaVJWanIJ0ESwgQogo-Lz0-JBnHgDw5iimDyIBJqMEUIGVcIYhxacJpkoGBrglDRVAMoCnZmWk5heDHRkQJCre3ywa0i8f5CLaxBQIj8trTgV5HyQqjIgbaFnpGdoqVQLAA%2C%2C&v=8.2.19).
